### PR TITLE
[Fix] Improve BorderColor for iOS 17 and later

### DIFF
--- a/Sources/Core/UIKit/Extension/UIView/UIView+LayerExtension.swift
+++ b/Sources/Core/UIKit/Extension/UIView/UIView+LayerExtension.swift
@@ -13,6 +13,10 @@ import SparkTheming
 
     /// CGColors need to be refreshed on trait changes
     func setBorderColor(from colorToken: any ColorToken) {
+        if #available(iOS 17.0, *) {
+            self.updateTraitsIfNeeded()
+        }
+
         self.layer.borderColor = colorToken.uiColor.resolvedColor(with: self.traitCollection).cgColor
     }
 


### PR DESCRIPTION
Before set the border, we call the `updateTraitsIfNeeded` to be sure that the current view used the correct traitCollection.

This fix can solved some troubles when the user switch the mode (light/dark)